### PR TITLE
feat(site): sort plugins by view count via GoatCounter stats

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -3,7 +3,7 @@ name: Build and deploy site
 on:
   # Chain after marketplace build or traffic collection completes
   workflow_run:
-    workflows: ["Build marketplace.json", "Collect traffic stats"]
+    workflows: ["Build marketplace.json", "Collect traffic stats", "Collect plugin view stats"]
     types: [completed]
   # Also trigger on site or stats changes
   push:

--- a/.github/workflows/goatcounter-stats.yml
+++ b/.github/workflows/goatcounter-stats.yml
@@ -1,0 +1,37 @@
+name: Collect plugin view stats
+
+on:
+  schedule:
+    # Daily at 14:00 UTC.
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Fetch plugin view counts
+        env:
+          GOATCOUNTER_TOKEN: ${{ secrets.GOATCOUNTER_TOKEN }}
+        run: node scripts/fetch-plugin-stats.js
+
+      - name: Commit and push stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats/plugins.json
+          if git diff --cached --quiet; then
+            echo "No changes"
+          else
+            git commit -m "chore: update plugin view stats"
+            git push
+          fi

--- a/scripts/fetch-plugin-stats.js
+++ b/scripts/fetch-plugin-stats.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Fetch top plugin pageview counts from GoatCounter and write stats/plugins.json.
+// Requires GOATCOUNTER_TOKEN in env. The /api/v0/stats/hits endpoint returns at
+// most the top 100 paths by visitor count, so plugins outside the top 100 fall
+// back to alphabetical sort on the site.
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const SITE = process.env.GOATCOUNTER_SITE || "nullorder";
+const TOKEN = process.env.GOATCOUNTER_TOKEN;
+if (!TOKEN) {
+  console.error("GOATCOUNTER_TOKEN env var required");
+  process.exit(1);
+}
+
+const start = process.env.GOATCOUNTER_START || "2024-01-01T00:00:00Z";
+const end = new Date().toISOString();
+
+const url = new URL(`https://${SITE}.goatcounter.com/api/v0/stats/hits`);
+url.searchParams.set("start", start);
+url.searchParams.set("end", end);
+url.searchParams.set("limit", "100");
+
+const res = await fetch(url, {
+  headers: { Authorization: `Bearer ${TOKEN}` },
+});
+
+if (!res.ok) {
+  console.error(`GoatCounter API ${res.status}: ${await res.text()}`);
+  process.exit(1);
+}
+
+const data = await res.json();
+
+const marketplace = JSON.parse(
+  readFileSync(resolve(REPO_ROOT, ".claude-plugin/marketplace.json"), "utf-8"),
+);
+const knownPlugins = new Set(
+  (marketplace.plugins || []).map((p) => p.name),
+);
+
+const counts = {};
+for (const hit of data.hits || []) {
+  const m = hit.path?.match(/^\/plugins\/([^/?#]+)\/?$/);
+  if (!m) continue;
+  const name = decodeURIComponent(m[1]);
+  if (!knownPlugins.has(name)) continue;
+  counts[name] = hit.count || 0;
+}
+
+const out = {
+  generated_at: new Date().toISOString(),
+  source: "goatcounter",
+  range: { start, end },
+  plugins: counts,
+};
+
+mkdirSync(resolve(REPO_ROOT, "stats"), { recursive: true });
+writeFileSync(
+  resolve(REPO_ROOT, "stats/plugins.json"),
+  JSON.stringify(out, null, 2) + "\n",
+);
+
+console.log(
+  `Wrote stats/plugins.json with counts for ${Object.keys(counts).length} plugins (out of ${data.hits?.length ?? 0} top paths returned).`,
+);

--- a/site/src/lib/plugins.ts
+++ b/site/src/lib/plugins.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const marketplacePath = resolve(
+  process.cwd(),
+  "../.claude-plugin/marketplace.json",
+);
+const statsPath = resolve(process.cwd(), "../stats/plugins.json");
+
+export type Plugin = Record<string, any> & { name: string };
+
+function loadViewCounts(): Record<string, number> {
+  try {
+    const stats = JSON.parse(readFileSync(statsPath, "utf-8"));
+    return stats.plugins || {};
+  } catch {
+    return {};
+  }
+}
+
+export function loadPlugins(): Plugin[] {
+  const marketplace = JSON.parse(readFileSync(marketplacePath, "utf-8"));
+  const plugins: Plugin[] = marketplace.plugins || [];
+  const views = loadViewCounts();
+
+  return [...plugins].sort((a, b) => {
+    const av = views[a.name] ?? -1;
+    const bv = views[b.name] ?? -1;
+    if (av !== bv) return bv - av;
+    return a.name.localeCompare(b.name);
+  });
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,15 +8,9 @@ import PluginCard from "../components/PluginCard.astro";
 import Cta from "../components/Cta.astro";
 import Collaborators from "../components/Collaborators.astro";
 import Footer from "../components/Footer.astro";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { loadPlugins } from "../lib/plugins";
 
-const marketplacePath = resolve(
-  process.cwd(),
-  "../.claude-plugin/marketplace.json",
-);
-const marketplace = JSON.parse(readFileSync(marketplacePath, "utf-8"));
-const plugins = marketplace.plugins || [];
+const plugins = loadPlugins();
 
 const categories = [
   ...new Set(plugins.map((p: any) => p.category)),

--- a/site/src/pages/plugins.json.ts
+++ b/site/src/pages/plugins.json.ts
@@ -1,15 +1,9 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { loadPlugins } from "../lib/plugins";
 
 export const prerender = true;
 
 export async function GET() {
-  const marketplacePath = resolve(
-    process.cwd(),
-    "../.claude-plugin/marketplace.json",
-  );
-  const marketplace = JSON.parse(readFileSync(marketplacePath, "utf-8"));
-  return new Response(JSON.stringify(marketplace.plugins || []), {
+  return new Response(JSON.stringify(loadPlugins()), {
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": "public, max-age=300",

--- a/stats/plugins.json
+++ b/stats/plugins.json
@@ -1,0 +1,5 @@
+{
+  "generated_at": null,
+  "source": "goatcounter",
+  "plugins": {}
+}


### PR DESCRIPTION
Add a daily GitHub Actions workflow that queries GoatCounter's `/api/v0/stats/hits` API and writes per-plugin pageview counts to `stats/plugins.json`. The site's build now reads those counts and sorts plugins by popularity (descending), falling back to alphabetical order for plugins outside GoatCounter's top-100 response limit.

Also extract shared plugin-loading logic into `site/src/lib/plugins.ts` to avoid duplicating file-read and sort code across `index.astro` and `plugins.json.ts`. The deploy workflow now re-triggers when the new stats-collection workflow completes.
