### PR TITLE
chore(github): generalize default PR template for all change types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,22 @@
-## Add Plugin
+## Summary
 
-**Plugin name:**
-**Source:** <!-- e.g. GitHub repo, Git URL, npm package -->
-**License:** <!-- e.g. MIT, Apache-2.0 -->
-**Category:** <!-- one of: development, testing, devops, security, documentation, productivity, data, design, other -->
-**Type / tags:** <!-- must include ≥1 of: skills, agents, hooks, commands, mcp-servers, lsp-servers, integration, other. Free-form descriptors allowed alongside, e.g. ["skills", "python"] -->
+<!-- What does this PR change, and why? -->
 
-> **Using `other`?** If you set the category or a type tag to `other` because nothing else fits, please briefly explain why in the description below — it helps us decide whether to add a new category/type later.
+### Type of change
+
+- [ ] Add a plugin → please use the [add-plugin template](?template=add-plugin.md) instead
+- [ ] Update a plugin → please use the [update-plugin template](?template=update-plugin.md) instead
+- [ ] Remove a plugin → please use the [remove-plugin template](?template=remove-plugin.md) instead
+- [ ] Marketplace / registry change (schema, validation, `plugins/` tooling)
+- [ ] Site / docs change (landing page, README, content)
+- [ ] CI / workflow / repo tooling
+- [ ] Bug fix
+- [ ] Other
 
 ### Checklist
 
 - [ ] I have read and understood the [contributing guidelines](../CONTRIBUTING.md)
-- [ ] Plugin has a valid `.claude-plugin/plugin.json` manifest
-- [ ] Plugin has a `README.md`
-- [ ] Plugin has a `LICENSE`
-- [ ] Plugin name is kebab-case
-- [ ] `category` is set to one of the allowed values
-- [ ] `tags` includes at least one component type (skills/agents/hooks/commands/mcp-servers/lsp-servers/integration/other)
-- [ ] Plugin file added to `plugins/` directory (do not edit `marketplace.json`)
-- [ ] Tested locally with `/plugin marketplace add` and `/plugin install`
-
-### What does this plugin do?
-
-<!-- Brief description -->
-
----
-
-<sub>Updating or removing a plugin instead? Use [`?template=update-plugin.md`](?template=update-plugin.md) or [`?template=remove-plugin.md`](?template=remove-plugin.md) in the URL.</sub>
+- [ ] Changes are scoped and focused on a single concern
+- [ ] Tested locally where applicable
+- [ ] Updated relevant docs (README, site content, etc.) if behavior changed
+- [ ] Did **not** hand-edit `marketplace.json` (it is generated)


### PR DESCRIPTION
The previous template was scoped only to "Add Plugin" PRs, requiring contributors to manually swap templates for updates, removals, or non-plugin changes. Replace it with a general-purpose template that covers all change types via a checklist, and points plugin-specific workflows to the dedicated per-operation templates.

Checklist items are now scoped to universal concerns (focused changes, local testing, docs updates, not editing `marketplace.json`) rather than plugin-manifest specifics, which belong in the add/update/remove templates.
