### PR TITLE
fix(site): correct theme colors for iOS Safari safe areas and overscroll

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -38,10 +38,11 @@ const imageUrl = new URL(image, Astro.site).toString();
     </script>
     <!-- GoatCounter -->
     <script is:inline data-goatcounter="https://nullorder.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content={description} />
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1" />
-    <meta name="theme-color" content="#0b1020" />
+    <meta name="theme-color" content="#0b1020" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f0f0f0" media="(prefers-color-scheme: light)" />
     {author && <meta name="author" content={author} />}
     <link rel="canonical" href={canonicalUrl} />
     <link rel="alternate" type="application/xml" title="Sitemap" href="/sitemap.xml" />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -7,6 +7,18 @@
   --font-pixel: "Pixeled", monospace;
 }
 
+/* Base background so iOS Safari overscroll / safe-area regions match the theme
+   instead of falling through to default white. */
+html,
+body {
+  background-color: #0b1020;
+}
+
+html.light,
+html.light body {
+  background-color: #f0f0f0;
+}
+
 a,
 button,
 label,


### PR DESCRIPTION
iOS Safari shows a white background in overscroll bounce regions and safe-area insets (notch, home indicator) when `background-color` isn't set on `html`/`body`. Add explicit background rules for both dark (`#0b1020`) and light (`#f0f0f0`) modes to match the page theme.

Also split the single `theme-color` meta tag into two `media`-query variants so browser chrome reflects the active color scheme, and add `viewport-fit=cover` to extend the viewport into safe-area insets.
