### PR TITLE
fix(site): pre-bake plugin repo stats at build time

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -3,7 +3,7 @@ name: Build and deploy site
 on:
   # Chain after marketplace build or traffic collection completes
   workflow_run:
-    workflows: ["Build marketplace.json", "Collect traffic stats", "Collect plugin view stats"]
+    workflows: ["Build marketplace.json", "Collect traffic stats", "Collect plugin view stats", "Collect plugin repo stats"]
     types: [completed]
   # Also trigger on site or stats changes
   push:

--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -1,0 +1,39 @@
+name: Collect plugin repo stats
+
+on:
+  schedule:
+    # Daily at 13:00 UTC. Plugin repo metadata (stars, forks, latest release)
+    # changes slowly; daily is plenty.
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Fetch repo stats
+        env:
+          # GITHUB_TOKEN gives 5000 req/hr — plenty for the ~80 unique repos.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/fetch-repo-stats.js
+
+      - name: Commit and push stats
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats/repos.json
+          if git diff --cached --quiet; then
+            echo "No changes"
+          else
+            git commit -m "chore: update plugin repo stats"
+            git push
+          fi

--- a/scripts/fetch-repo-stats.js
+++ b/scripts/fetch-repo-stats.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Fetch repo metadata for every GitHub-sourced plugin and write
+// stats/repos.json. Runs in CI with GITHUB_TOKEN (5000 req/hr) so the site
+// can render repo stats server-side instead of hammering the unauthenticated
+// browser API (60 req/hr per IP, which exhausts fast behind a CDN).
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const TOKEN = process.env.GITHUB_TOKEN;
+if (!TOKEN) {
+  console.error("GITHUB_TOKEN env var required");
+  process.exit(1);
+}
+
+const marketplace = JSON.parse(
+  readFileSync(resolve(REPO_ROOT, ".claude-plugin/marketplace.json"), "utf-8"),
+);
+
+function extractRepo(source) {
+  if (!source || typeof source === "string") return "";
+  if (source.source === "github") return source.repo || "";
+  if (source.source === "url" || source.source === "git-subdir") {
+    const m = (source.url || "").match(
+      /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/,
+    );
+    return m ? m[1] : "";
+  }
+  return "";
+}
+
+const repos = new Set();
+for (const p of marketplace.plugins || []) {
+  const r = extractRepo(p.source);
+  if (r) repos.add(r);
+}
+
+const headers = {
+  Authorization: `Bearer ${TOKEN}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "agenthub-stats",
+};
+
+async function fetchRepo(repo) {
+  const [repoRes, releaseRes] = await Promise.all([
+    fetch(`https://api.github.com/repos/${repo}`, { headers }),
+    fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers }),
+  ]);
+
+  if (!repoRes.ok) {
+    return { error: `repo ${repoRes.status}` };
+  }
+  const data = await repoRes.json();
+
+  let release = null;
+  if (releaseRes.ok) {
+    const r = await releaseRes.json();
+    release = {
+      tag: r.tag_name,
+      url: r.html_url,
+      published_at: r.published_at,
+    };
+  }
+
+  return {
+    stars: data.stargazers_count ?? 0,
+    forks: data.forks_count ?? 0,
+    watchers: data.subscribers_count ?? 0,
+    issues: data.open_issues_count ?? 0,
+    pushed_at: data.pushed_at,
+    language: data.language ?? null,
+    archived: Boolean(data.archived),
+    release,
+  };
+}
+
+const out = {};
+const errors = [];
+const sorted = [...repos].sort();
+
+for (const repo of sorted) {
+  try {
+    const r = await fetchRepo(repo);
+    if (r.error) {
+      errors.push(`${repo}: ${r.error}`);
+      continue;
+    }
+    out[repo] = r;
+  } catch (e) {
+    errors.push(`${repo}: ${e.message}`);
+  }
+}
+
+const result = {
+  generated_at: new Date().toISOString(),
+  repos: out,
+};
+
+mkdirSync(resolve(REPO_ROOT, "stats"), { recursive: true });
+writeFileSync(
+  resolve(REPO_ROOT, "stats/repos.json"),
+  JSON.stringify(result, null, 2) + "\n",
+);
+
+console.log(
+  `Wrote stats/repos.json with ${Object.keys(out).length}/${sorted.length} repos.`,
+);
+if (errors.length) {
+  console.error(`Skipped ${errors.length}:`);
+  for (const e of errors) console.error(`  ${e}`);
+}

--- a/site/src/components/plugin/RepoStats.astro
+++ b/site/src/components/plugin/RepoStats.astro
@@ -1,33 +1,127 @@
 ---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 interface Props {
   repo: string;
 }
 
 const { repo } = Astro.props;
 
-const skeleton = `<span class="inline-block h-4 w-10 animate-pulse rounded bg-white/10"></span>`;
-const tiles: Array<{ label: string; field: string; size: "lg" | "sm" }> = [
-  { label: "Stars", field: "stars", size: "lg" },
-  { label: "Forks", field: "forks", size: "lg" },
-  { label: "Watchers", field: "watchers", size: "lg" },
-  { label: "Open issues", field: "issues", size: "lg" },
-  { label: "Last commit", field: "pushed", size: "sm" },
-];
+type RepoStat = {
+  stars: number;
+  forks: number;
+  watchers: number;
+  issues: number;
+  pushed_at: string;
+  language: string | null;
+  archived: boolean;
+  release: { tag: string; url: string; published_at: string } | null;
+};
+
+let stats: RepoStat | null = null;
+let generatedAt: string | null = null;
+
+try {
+  const raw = readFileSync(
+    resolve(process.cwd(), "../stats/repos.json"),
+    "utf-8",
+  );
+  const parsed = JSON.parse(raw) as {
+    generated_at?: string;
+    repos?: Record<string, RepoStat>;
+  };
+  stats = parsed.repos?.[repo] ?? null;
+  generatedAt = parsed.generated_at ?? null;
+} catch {
+  stats = null;
+}
+
+const nf = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+function formatRelative(iso: string | null | undefined, nowMs: number): string {
+  if (!iso) return "—";
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return "—";
+  const diffSec = Math.round((then - nowMs) / 1000);
+  const abs = Math.abs(diffSec);
+  const units: [Intl.RelativeTimeFormatUnit, number][] = [
+    ["year", 365 * 24 * 3600],
+    ["month", 30 * 24 * 3600],
+    ["week", 7 * 24 * 3600],
+    ["day", 24 * 3600],
+    ["hour", 3600],
+    ["minute", 60],
+  ];
+  for (const [unit, secs] of units) {
+    if (abs >= secs) return rtf.format(Math.round(diffSec / secs), unit);
+  }
+  return rtf.format(diffSec, "second");
+}
+
+const now = Date.now();
+
+const tiles: Array<{ label: string; value: string; title: string; size: "lg" | "sm" }> = stats
+  ? [
+      {
+        label: "Stars",
+        value: nf.format(stats.stars),
+        title: `${stats.stars.toLocaleString()} stars`,
+        size: "lg",
+      },
+      {
+        label: "Forks",
+        value: nf.format(stats.forks),
+        title: `${stats.forks.toLocaleString()} forks`,
+        size: "lg",
+      },
+      {
+        label: "Watchers",
+        value: nf.format(stats.watchers),
+        title: `${stats.watchers.toLocaleString()} watching`,
+        size: "lg",
+      },
+      {
+        label: "Open issues",
+        value: nf.format(stats.issues),
+        title: `${stats.issues.toLocaleString()} open issues + PRs`,
+        size: "lg",
+      },
+      {
+        label: "Last commit",
+        value: formatRelative(stats.pushed_at, now),
+        title: stats.pushed_at ? new Date(stats.pushed_at).toLocaleString() : "",
+        size: "sm",
+      },
+    ]
+  : [
+      { label: "Stars", value: "—", title: "", size: "lg" },
+      { label: "Forks", value: "—", title: "", size: "lg" },
+      { label: "Watchers", value: "—", title: "", size: "lg" },
+      { label: "Open issues", value: "—", title: "", size: "lg" },
+      { label: "Last commit", value: "—", title: "", size: "sm" },
+    ];
+
+const metaText = stats
+  ? `Updated ${formatRelative(generatedAt, now)}`
+  : "Stats unavailable";
 ---
 
-<div class="gh-stats mb-6 border-t border-white/5 pt-5" data-repo={repo}>
+<div class="gh-stats mb-6 border-t border-white/5 pt-5">
   <div class="mb-3 flex items-center justify-between">
     <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-500">
       Repository stats
     </h3>
-    <span class="gh-stats-meta text-xs text-gray-600" data-state="loading">
-      Loading from GitHub…
-    </span>
+    <span class="text-xs text-gray-600">{metaText}</span>
   </div>
 
   <div class="grid grid-cols-2 gap-2 sm:grid-cols-5">
     {
-      tiles.map(({ label, field, size }) => (
+      tiles.map(({ label, value, title, size }) => (
         <div class="rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2.5">
           <div class="text-[10px] font-medium uppercase tracking-wider text-gray-500">
             {label}
@@ -37,251 +131,46 @@ const tiles: Array<{ label: string; field: string; size: "lg" | "sm" }> = [
               "mt-1 font-mono font-semibold text-white",
               size === "lg" ? "text-lg" : "text-sm",
             ]}
-            data-field={field}
-            set:html={skeleton}
-          />
+            title={title}
+          >
+            {value}
+          </div>
         </div>
       ))
     }
   </div>
 
-  <div
-    class="gh-extra mt-3 hidden flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-400"
-  >
-    <span class="gh-release hidden">
-      <span class="text-gray-500">Latest release:</span>
-      <a
-        class="gh-release-link ml-1 font-mono text-blue-400 hover:underline"
-        target="_blank"
-        rel="noopener noreferrer"></a>
-      <span class="gh-release-age ml-1 text-gray-500"></span>
-    </span>
-    <span class="gh-language hidden">
-      <span class="text-gray-500">Primary language:</span>
-      <span class="gh-language-name ml-1 text-gray-300"></span>
-    </span>
-    <span
-      class="gh-archived hidden rounded bg-yellow-400/10 px-2 py-0.5 text-yellow-300"
-    >
-      Archived
-    </span>
-  </div>
+  {
+    stats && (stats.release || stats.language || stats.archived) && (
+      <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-400">
+        {stats.release && (
+          <span>
+            <span class="text-gray-500">Latest release:</span>
+            <a
+              class="ml-1 font-mono text-blue-400 hover:underline"
+              href={stats.release.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {stats.release.tag}
+            </a>
+            <span class="ml-1 text-gray-500">
+              · {formatRelative(stats.release.published_at, now)}
+            </span>
+          </span>
+        )}
+        {stats.language && (
+          <span>
+            <span class="text-gray-500">Primary language:</span>
+            <span class="ml-1 text-gray-300">{stats.language}</span>
+          </span>
+        )}
+        {stats.archived && (
+          <span class="rounded bg-yellow-400/10 px-2 py-0.5 text-yellow-300">
+            Archived
+          </span>
+        )}
+      </div>
+    )
+  }
 </div>
-
-<script>
-  // Unauthenticated GitHub REST: 60 req/hr per IP. Cache per-repo in
-  // localStorage for 1 hour so navigation between plugin pages that share a
-  // repo costs zero network calls.
-  type RepoStats = {
-    stars: number;
-    forks: number;
-    watchers: number;
-    issues: number;
-    pushedAt: string;
-    language: string | null;
-    archived: boolean;
-    release?: { tag: string; url: string; publishedAt: string } | null;
-    fetchedAt: number;
-  };
-
-  const CACHE_TTL_MS = 60 * 60 * 1000;
-  const CACHE_PREFIX = "gh-stats:v1:";
-
-  const nf = new Intl.NumberFormat("en", {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  });
-  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-
-  function formatRelative(iso: string): string {
-    const then = new Date(iso).getTime();
-    if (!Number.isFinite(then)) return "—";
-    const diffSec = Math.round((then - Date.now()) / 1000);
-    const abs = Math.abs(diffSec);
-    const units: [Intl.RelativeTimeFormatUnit, number][] = [
-      ["year", 365 * 24 * 3600],
-      ["month", 30 * 24 * 3600],
-      ["week", 7 * 24 * 3600],
-      ["day", 24 * 3600],
-      ["hour", 3600],
-      ["minute", 60],
-    ];
-    for (const [unit, secs] of units) {
-      if (abs >= secs) return rtf.format(Math.round(diffSec / secs), unit);
-    }
-    return rtf.format(diffSec, "second");
-  }
-
-  function readCache(repo: string): RepoStats | null {
-    try {
-      const raw = localStorage.getItem(CACHE_PREFIX + repo);
-      if (!raw) return null;
-      const parsed = JSON.parse(raw) as RepoStats;
-      if (Date.now() - parsed.fetchedAt > CACHE_TTL_MS) return null;
-      return parsed;
-    } catch {
-      return null;
-    }
-  }
-
-  function writeCache(repo: string, stats: RepoStats): void {
-    try {
-      localStorage.setItem(CACHE_PREFIX + repo, JSON.stringify(stats));
-    } catch {
-      // quota or disabled storage — ignore
-    }
-  }
-
-  async function fetchRepoStats(repo: string): Promise<RepoStats | null> {
-    const [repoRes, releaseRes] = await Promise.all([
-      fetch(`https://api.github.com/repos/${repo}`, {
-        headers: { Accept: "application/vnd.github+json" },
-      }),
-      fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
-        headers: { Accept: "application/vnd.github+json" },
-      }).catch(() => null),
-    ]);
-
-    if (!repoRes.ok) return null;
-    const data = await repoRes.json();
-
-    let release: RepoStats["release"] = null;
-    if (releaseRes && releaseRes.ok) {
-      const r = await releaseRes.json();
-      release = {
-        tag: r.tag_name,
-        url: r.html_url,
-        publishedAt: r.published_at,
-      };
-    }
-
-    return {
-      stars: data.stargazers_count ?? 0,
-      forks: data.forks_count ?? 0,
-      watchers: data.subscribers_count ?? 0,
-      issues: data.open_issues_count ?? 0,
-      pushedAt: data.pushed_at,
-      language: data.language ?? null,
-      archived: Boolean(data.archived),
-      release,
-      fetchedAt: Date.now(),
-    };
-  }
-
-  function render(container: HTMLElement, stats: RepoStats): void {
-    const set = (field: string, text: string, title?: string) => {
-      const el = container.querySelector<HTMLElement>(
-        `[data-field="${field}"]`,
-      );
-      if (!el) return;
-      el.textContent = text;
-      if (title) el.title = title;
-    };
-
-    set(
-      "stars",
-      nf.format(stats.stars),
-      `${stats.stars.toLocaleString()} stars`,
-    );
-    set(
-      "forks",
-      nf.format(stats.forks),
-      `${stats.forks.toLocaleString()} forks`,
-    );
-    set(
-      "watchers",
-      nf.format(stats.watchers),
-      `${stats.watchers.toLocaleString()} watching`,
-    );
-    set(
-      "issues",
-      nf.format(stats.issues),
-      `${stats.issues.toLocaleString()} open issues + PRs`,
-    );
-    set(
-      "pushed",
-      stats.pushedAt ? formatRelative(stats.pushedAt) : "—",
-      stats.pushedAt ? new Date(stats.pushedAt).toLocaleString() : "",
-    );
-
-    const extra = container.querySelector<HTMLElement>(".gh-extra");
-    if (extra) {
-      let shown = false;
-
-      if (stats.release) {
-        const wrap = extra.querySelector<HTMLElement>(".gh-release");
-        const link = extra.querySelector<HTMLAnchorElement>(".gh-release-link");
-        const age = extra.querySelector<HTMLElement>(".gh-release-age");
-        if (wrap && link && age) {
-          link.href = stats.release.url;
-          link.textContent = stats.release.tag;
-          age.textContent = `· ${formatRelative(stats.release.publishedAt)}`;
-          wrap.classList.remove("hidden");
-          shown = true;
-        }
-      }
-
-      if (stats.language) {
-        const wrap = extra.querySelector<HTMLElement>(".gh-language");
-        const name = extra.querySelector<HTMLElement>(".gh-language-name");
-        if (wrap && name) {
-          name.textContent = stats.language;
-          wrap.classList.remove("hidden");
-          shown = true;
-        }
-      }
-
-      if (stats.archived) {
-        extra.querySelector(".gh-archived")?.classList.remove("hidden");
-        shown = true;
-      }
-
-      if (shown) extra.classList.remove("hidden");
-      extra.classList.add("flex");
-    }
-
-    const meta = container.querySelector<HTMLElement>(".gh-stats-meta");
-    if (meta) {
-      meta.textContent = `Updated ${formatRelative(new Date(stats.fetchedAt).toISOString())}`;
-      meta.dataset.state = "ready";
-    }
-  }
-
-  function renderError(container: HTMLElement): void {
-    container.querySelectorAll<HTMLElement>("[data-field]").forEach((el) => {
-      el.textContent = "—";
-    });
-    const meta = container.querySelector<HTMLElement>(".gh-stats-meta");
-    if (meta) {
-      meta.textContent = "Stats unavailable";
-      meta.dataset.state = "error";
-    }
-  }
-
-  async function hydrate(container: HTMLElement): Promise<void> {
-    const repo = container.dataset.repo;
-    if (!repo) return;
-
-    const cached = readCache(repo);
-    if (cached) {
-      render(container, cached);
-      return;
-    }
-
-    try {
-      const stats = await fetchRepoStats(repo);
-      if (!stats) {
-        renderError(container);
-        return;
-      }
-      writeCache(repo, stats);
-      render(container, stats);
-    } catch {
-      renderError(container);
-    }
-  }
-
-  document
-    .querySelectorAll<HTMLElement>(".gh-stats")
-    .forEach((el) => void hydrate(el));
-</script>

--- a/stats/repos.json
+++ b/stats/repos.json
@@ -1,0 +1,975 @@
+{
+  "generated_at": "2026-04-25T17:00:49.428Z",
+  "repos": {
+    "Aaronontheweb/dotnet-skills": {
+      "stars": 879,
+      "forks": 79,
+      "watchers": 16,
+      "issues": 2,
+      "pushed_at": "2026-04-16T02:05:56Z",
+      "language": "Shell",
+      "archived": false,
+      "release": {
+        "tag": "v1.3.2",
+        "url": "https://github.com/Aaronontheweb/dotnet-skills/releases/tag/v1.3.2",
+        "published_at": "2026-04-16T02:06:10Z"
+      }
+    },
+    "CharlesWiltgen/Axiom": {
+      "stars": 855,
+      "forks": 65,
+      "watchers": 6,
+      "issues": 5,
+      "pushed_at": "2026-04-23T20:51:14Z",
+      "language": "Go",
+      "archived": false,
+      "release": null
+    },
+    "Comfy-Org/comfy-claude-prompt-library": {
+      "stars": 127,
+      "forks": 18,
+      "watchers": 3,
+      "issues": 5,
+      "pushed_at": "2025-10-26T08:37:42Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": null
+    },
+    "DrCatHicks/learning-opportunities": {
+      "stars": 840,
+      "forks": 39,
+      "watchers": 9,
+      "issues": 1,
+      "pushed_at": "2026-03-10T16:02:46Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "EveryInc/compound-engineering-plugin": {
+      "stars": 15506,
+      "forks": 1198,
+      "watchers": 88,
+      "issues": 59,
+      "pushed_at": "2026-04-25T09:00:05Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "compound-engineering-v3.1.0",
+        "url": "https://github.com/EveryInc/compound-engineering-plugin/releases/tag/compound-engineering-v3.1.0",
+        "published_at": "2026-04-24T22:17:10Z"
+      }
+    },
+    "Jeffallan/claude-skills": {
+      "stars": 8549,
+      "forks": 698,
+      "watchers": 56,
+      "issues": 27,
+      "pushed_at": "2026-04-21T14:49:45Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v0.4.12",
+        "url": "https://github.com/Jeffallan/claude-skills/releases/tag/v0.4.12",
+        "published_at": "2026-04-21T14:50:11Z"
+      }
+    },
+    "JuliusBrussee/caveman": {
+      "stars": 46326,
+      "forks": 2424,
+      "watchers": 104,
+      "issues": 148,
+      "pushed_at": "2026-04-18T10:11:39Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v1.6.0",
+        "url": "https://github.com/JuliusBrussee/caveman/releases/tag/v1.6.0",
+        "published_at": "2026-04-15T12:51:06Z"
+      }
+    },
+    "K-Dense-AI/claude-scientific-skills": {
+      "stars": 19397,
+      "forks": 2171,
+      "watchers": 119,
+      "issues": 41,
+      "pushed_at": "2026-04-20T10:43:53Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v2.37.1",
+        "url": "https://github.com/K-Dense-AI/scientific-agent-skills/releases/tag/v2.37.1",
+        "published_at": "2026-04-13T00:44:28Z"
+      }
+    },
+    "Lum1104/Understand-Anything": {
+      "stars": 8897,
+      "forks": 754,
+      "watchers": 37,
+      "issues": 5,
+      "pushed_at": "2026-04-25T13:00:57Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v2.3.1",
+        "url": "https://github.com/Lum1104/Understand-Anything/releases/tag/v2.3.1",
+        "published_at": "2026-04-12T07:25:39Z"
+      }
+    },
+    "OthmanAdi/planning-with-files": {
+      "stars": 19599,
+      "forks": 1760,
+      "watchers": 98,
+      "issues": 5,
+      "pushed_at": "2026-04-21T13:56:38Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v2.35.0",
+        "url": "https://github.com/OthmanAdi/planning-with-files/releases/tag/v2.35.0",
+        "published_at": "2026-04-21T13:57:03Z"
+      }
+    },
+    "PabloLION/bmad-plugin": {
+      "stars": 9,
+      "forks": 2,
+      "watchers": 1,
+      "issues": 8,
+      "pushed_at": "2026-04-01T11:53:26Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v6.2.2.0",
+        "url": "https://github.com/PabloLION/bmad-plugin/releases/tag/v6.2.2.0",
+        "published_at": "2026-03-31T09:41:34Z"
+      }
+    },
+    "Sagart-cactus/claude-k8s-plugin": {
+      "stars": 33,
+      "forks": 3,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-02-28T17:05:52Z",
+      "language": "Shell",
+      "archived": false,
+      "release": {
+        "tag": "v0.1.3",
+        "url": "https://github.com/Sagart-cactus/claude-k8s-plugin/releases/tag/v0.1.3",
+        "published_at": "2026-02-08T09:05:33Z"
+      }
+    },
+    "affaan-m/everything-claude-code": {
+      "stars": 166807,
+      "forks": 25870,
+      "watchers": 861,
+      "issues": 161,
+      "pushed_at": "2026-04-23T06:14:29Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v1.10.0",
+        "url": "https://github.com/affaan-m/everything-claude-code/releases/tag/v1.10.0",
+        "published_at": "2026-04-05T20:20:57Z"
+      }
+    },
+    "akin-ozer/cc-devops-skills": {
+      "stars": 191,
+      "forks": 21,
+      "watchers": 2,
+      "issues": 1,
+      "pushed_at": "2026-03-27T07:54:57Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v1.0.0",
+        "url": "https://github.com/akin-ozer/cc-devops-skills/releases/tag/v1.0.0",
+        "published_at": "2026-03-04T06:44:32Z"
+      }
+    },
+    "alexanderop/claude-code-builder": {
+      "stars": 34,
+      "forks": 3,
+      "watchers": 1,
+      "issues": 0,
+      "pushed_at": "2025-11-16T12:37:57Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "alirezarezvani/claude-skills": {
+      "stars": 12688,
+      "forks": 1677,
+      "watchers": 121,
+      "issues": 20,
+      "pushed_at": "2026-04-20T12:37:36Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v2.0.0",
+        "url": "https://github.com/alirezarezvani/claude-skills/releases/tag/v2.0.0",
+        "published_at": "2026-03-04T02:22:23Z"
+      }
+    },
+    "anistark/ani-skills": {
+      "stars": 0,
+      "forks": 0,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-04-16T18:35:45Z",
+      "language": "Just",
+      "archived": false,
+      "release": null
+    },
+    "anistark/sutras": {
+      "stars": 5,
+      "forks": 0,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-04-17T19:29:29Z",
+      "language": "Python",
+      "archived": false,
+      "release": null
+    },
+    "astral-sh/claude-code-plugins": {
+      "stars": 221,
+      "forks": 9,
+      "watchers": 1,
+      "issues": 10,
+      "pushed_at": "2026-02-27T16:09:15Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "athola/claude-night-market": {
+      "stars": 261,
+      "forks": 22,
+      "watchers": 1,
+      "issues": 13,
+      "pushed_at": "2026-04-25T05:33:19Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v1.9.2",
+        "url": "https://github.com/athola/claude-night-market/releases/tag/v1.9.2",
+        "published_at": "2026-04-25T03:18:20Z"
+      }
+    },
+    "automazeio/ccpm": {
+      "stars": 8028,
+      "forks": 812,
+      "watchers": 40,
+      "issues": 2,
+      "pushed_at": "2026-03-18T12:15:24Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "awslabs/agent-plugins": {
+      "stars": 625,
+      "forks": 80,
+      "watchers": 6,
+      "issues": 36,
+      "pushed_at": "2026-04-23T23:06:38Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "1.0.0",
+        "url": "https://github.com/awslabs/agent-plugins/releases/tag/1.0.0",
+        "published_at": "2026-02-18T16:30:08Z"
+      }
+    },
+    "blader/humanizer": {
+      "stars": 15150,
+      "forks": 1365,
+      "watchers": 128,
+      "issues": 49,
+      "pushed_at": "2026-04-01T05:09:58Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "blader/napkin": {
+      "stars": 495,
+      "forks": 31,
+      "watchers": 6,
+      "issues": 0,
+      "pushed_at": "2026-02-21T01:02:32Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "boostvolt/claude-code-lsps": {
+      "stars": 148,
+      "forks": 16,
+      "watchers": 1,
+      "issues": 1,
+      "pushed_at": "2026-01-18T12:05:00Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "camilooscargbaptista/cto-toolkit": {
+      "stars": 5,
+      "forks": 0,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-03-26T01:39:06Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "claude-did-this/claude-hub": {
+      "stars": 459,
+      "forks": 37,
+      "watchers": 3,
+      "issues": 46,
+      "pushed_at": "2025-10-27T14:06:25Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v0.1.1",
+        "url": "https://github.com/claude-did-this/claude-hub/releases/tag/v0.1.1",
+        "published_at": "2025-05-31T18:48:30Z"
+      }
+    },
+    "cloudflare/skills": {
+      "stars": 1281,
+      "forks": 103,
+      "watchers": 11,
+      "issues": 8,
+      "pushed_at": "2026-04-23T20:59:25Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "dagger/container-use": {
+      "stars": 3746,
+      "forks": 190,
+      "watchers": 11,
+      "issues": 76,
+      "pushed_at": "2026-02-23T12:37:47Z",
+      "language": "Go",
+      "archived": false,
+      "release": {
+        "tag": "v0.4.2",
+        "url": "https://github.com/dagger/container-use/releases/tag/v0.4.2",
+        "published_at": "2025-08-19T22:31:40Z"
+      }
+    },
+    "danielscholl/claude-sdlc": {
+      "stars": 8,
+      "forks": 1,
+      "watchers": 0,
+      "issues": 2,
+      "pushed_at": "2026-04-04T18:20:54Z",
+      "language": "Python",
+      "archived": false,
+      "release": null
+    },
+    "docker/claude-plugins": {
+      "stars": 16,
+      "forks": 4,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-02-27T14:32:21Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "dominikmartn/nothing-design-skill": {
+      "stars": 2149,
+      "forks": 132,
+      "watchers": 5,
+      "issues": 3,
+      "pushed_at": "2026-04-01T05:40:04Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "edamametechnologies/edamame_claude_code": {
+      "stars": 0,
+      "forks": 0,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-04-18T20:39:11Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": null
+    },
+    "egorfedorov/claude-context-optimizer": {
+      "stars": 45,
+      "forks": 8,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-03-28T12:26:44Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v3.5.0",
+        "url": "https://github.com/egorfedorov/claude-context-optimizer/releases/tag/v3.5.0",
+        "published_at": "2026-03-26T02:35:54Z"
+      }
+    },
+    "elastic/agent-skills": {
+      "stars": 380,
+      "forks": 27,
+      "watchers": 5,
+      "issues": 3,
+      "pushed_at": "2026-04-24T18:45:30Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v0.2.4",
+        "url": "https://github.com/elastic/agent-skills/releases/tag/v0.2.4",
+        "published_at": "2026-04-24T18:45:31Z"
+      }
+    },
+    "expo/skills": {
+      "stars": 1786,
+      "forks": 83,
+      "watchers": 20,
+      "issues": 19,
+      "pushed_at": "2026-04-24T14:49:02Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": null
+    },
+    "firebase/agent-skills": {
+      "stars": 252,
+      "forks": 41,
+      "watchers": 4,
+      "issues": 18,
+      "pushed_at": "2026-04-24T20:59:59Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": null
+    },
+    "frankbria/ralph-claude-code": {
+      "stars": 8845,
+      "forks": 662,
+      "watchers": 48,
+      "issues": 37,
+      "pushed_at": "2026-04-13T18:22:32Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "garrytan/gstack": {
+      "stars": 83086,
+      "forks": 12100,
+      "watchers": 509,
+      "issues": 449,
+      "pushed_at": "2026-04-25T15:45:20Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": null
+    },
+    "geoffrey-young/anthropic-hackathon-2026": {
+      "stars": 1,
+      "forks": 0,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-02-21T05:13:13Z",
+      "language": "Python",
+      "archived": false,
+      "release": null
+    },
+    "getsentry/sentry-for-ai": {
+      "stars": 139,
+      "forks": 18,
+      "watchers": 0,
+      "issues": 5,
+      "pushed_at": "2026-04-24T07:30:29Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "giuseppe-trisciuoglio/developer-kit": {
+      "stars": 221,
+      "forks": 23,
+      "watchers": 4,
+      "issues": 14,
+      "pushed_at": "2026-04-21T16:41:13Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v2.8.1",
+        "url": "https://github.com/giuseppe-trisciuoglio/developer-kit/releases/tag/v2.8.1",
+        "published_at": "2026-04-20T06:58:33Z"
+      }
+    },
+    "gmickel/flow-next": {
+      "stars": 574,
+      "forks": 42,
+      "watchers": 10,
+      "issues": 12,
+      "pushed_at": "2026-04-25T13:40:46Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "flow-next-v0.38.0",
+        "url": "https://github.com/gmickel/flow-next/releases/tag/flow-next-v0.38.0",
+        "published_at": "2026-04-25T13:40:48Z"
+      }
+    },
+    "google-labs-code/stitch-skills": {
+      "stars": 4894,
+      "forks": 582,
+      "watchers": 45,
+      "issues": 27,
+      "pushed_at": "2026-03-27T17:16:19Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v0.1",
+        "url": "https://github.com/google-labs-code/stitch-skills/releases/tag/v0.1",
+        "published_at": "2026-03-04T21:34:14Z"
+      }
+    },
+    "greggh/claude-code.nvim": {
+      "stars": 2018,
+      "forks": 65,
+      "watchers": 10,
+      "issues": 54,
+      "pushed_at": "2026-02-04T14:44:51Z",
+      "language": "Lua",
+      "archived": false,
+      "release": {
+        "tag": "v0.4.3",
+        "url": "https://github.com/greggh/claude-code.nvim/releases/tag/v0.4.3",
+        "published_at": "2025-03-21T14:43:57Z"
+      }
+    },
+    "harish-garg/security-scanner-plugin": {
+      "stars": 7,
+      "forks": 1,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2025-10-10T06:09:14Z",
+      "language": null,
+      "archived": false,
+      "release": null
+    },
+    "hashicorp/agent-skills": {
+      "stars": 571,
+      "forks": 70,
+      "watchers": 12,
+      "issues": 23,
+      "pushed_at": "2026-04-25T01:11:36Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "huggingface/skills": {
+      "stars": 10311,
+      "forks": 646,
+      "watchers": 48,
+      "issues": 28,
+      "pushed_at": "2026-04-24T13:32:17Z",
+      "language": "Python",
+      "archived": false,
+      "release": null
+    },
+    "husniadil/cc-hooks": {
+      "stars": 17,
+      "forks": 3,
+      "watchers": 0,
+      "issues": 3,
+      "pushed_at": "2026-02-04T17:14:34Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v1.1.0",
+        "url": "https://github.com/husniadil/cc-hooks/releases/tag/v1.1.0",
+        "published_at": "2026-02-04T17:14:57Z"
+      }
+    },
+    "israelmirsky/claude-code-soul": {
+      "stars": 5,
+      "forks": 0,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-03-12T17:03:53Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "jarrodwatts/claude-hud": {
+      "stars": 20680,
+      "forks": 920,
+      "watchers": 32,
+      "issues": 3,
+      "pushed_at": "2026-04-25T00:30:11Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v0.0.12",
+        "url": "https://github.com/jarrodwatts/claude-hud/releases/tag/v0.0.12",
+        "published_at": "2026-04-04T06:56:07Z"
+      }
+    },
+    "johnlindquist/claude-hooks": {
+      "stars": 358,
+      "forks": 19,
+      "watchers": 3,
+      "issues": 5,
+      "pushed_at": "2025-08-08T03:19:00Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v2.4.0",
+        "url": "https://github.com/johnlindquist/claude-hooks/releases/tag/v2.4.0",
+        "published_at": "2025-08-01T14:45:16Z"
+      }
+    },
+    "kenryu42/claude-code-safety-net": {
+      "stars": 1279,
+      "forks": 59,
+      "watchers": 8,
+      "issues": 5,
+      "pushed_at": "2026-03-27T09:22:10Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v0.8.2",
+        "url": "https://github.com/kenryu42/claude-code-safety-net/releases/tag/v0.8.2",
+        "published_at": "2026-03-25T06:04:48Z"
+      }
+    },
+    "lackeyjb/playwright-skill": {
+      "stars": 2494,
+      "forks": 166,
+      "watchers": 10,
+      "issues": 16,
+      "pushed_at": "2025-12-19T16:23:38Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v4.1.0",
+        "url": "https://github.com/lackeyjb/playwright-skill/releases/tag/v4.1.0",
+        "published_at": "2025-12-02T12:46:30Z"
+      }
+    },
+    "major7apps/pensyve": {
+      "stars": 15,
+      "forks": 5,
+      "watchers": 1,
+      "issues": 12,
+      "pushed_at": "2026-04-23T12:58:35Z",
+      "language": "Rust",
+      "archived": false,
+      "release": {
+        "tag": "v1.3.1",
+        "url": "https://github.com/major7apps/pensyve/releases/tag/v1.3.1",
+        "published_at": "2026-04-20T15:16:59Z"
+      }
+    },
+    "nizos/tdd-guard": {
+      "stars": 2003,
+      "forks": 149,
+      "watchers": 15,
+      "issues": 27,
+      "pushed_at": "2026-04-23T20:04:44Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v1.6.5",
+        "url": "https://github.com/nizos/tdd-guard/releases/tag/v1.6.5",
+        "published_at": "2026-04-23T20:07:38Z"
+      }
+    },
+    "numman-ali/n-skills": {
+      "stars": 975,
+      "forks": 99,
+      "watchers": 15,
+      "issues": 17,
+      "pushed_at": "2026-03-22T00:26:58Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v1.3.2",
+        "url": "https://github.com/numman-ali/n-skills/releases/tag/v1.3.2",
+        "published_at": "2026-01-17T13:16:19Z"
+      }
+    },
+    "obra/superpowers": {
+      "stars": 167437,
+      "forks": 14736,
+      "watchers": 688,
+      "issues": 329,
+      "pushed_at": "2026-04-24T02:02:37Z",
+      "language": "Shell",
+      "archived": false,
+      "release": {
+        "tag": "v5.0.7",
+        "url": "https://github.com/obra/superpowers/releases/tag/v5.0.7",
+        "published_at": "2026-03-31T19:25:11Z"
+      }
+    },
+    "obra/superpowers-chrome": {
+      "stars": 260,
+      "forks": 38,
+      "watchers": 3,
+      "issues": 5,
+      "pushed_at": "2026-04-14T17:50:28Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v1.12.0",
+        "url": "https://github.com/obra/superpowers-chrome/releases/tag/v1.12.0",
+        "published_at": "2026-04-14T17:50:35Z"
+      }
+    },
+    "oliver-kriska/claude-elixir-phoenix": {
+      "stars": 290,
+      "forks": 24,
+      "watchers": 9,
+      "issues": 13,
+      "pushed_at": "2026-04-24T12:09:32Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v2.8.4",
+        "url": "https://github.com/oliver-kriska/claude-elixir-phoenix/releases/tag/v2.8.4",
+        "published_at": "2026-04-24T12:08:52Z"
+      }
+    },
+    "pdugan20/claudelint": {
+      "stars": 4,
+      "forks": 0,
+      "watchers": 1,
+      "issues": 31,
+      "pushed_at": "2026-04-20T11:55:20Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v0.3.0",
+        "url": "https://github.com/pdugan20/claudelint/releases/tag/v0.3.0",
+        "published_at": "2026-03-23T20:21:05Z"
+      }
+    },
+    "prajapatimehul/claude-aws-cost-saver": {
+      "stars": 16,
+      "forks": 4,
+      "watchers": 1,
+      "issues": 1,
+      "pushed_at": "2026-03-09T06:34:13Z",
+      "language": "Python",
+      "archived": false,
+      "release": null
+    },
+    "ryoppippi/ccusage": {
+      "stars": 13338,
+      "forks": 509,
+      "watchers": 21,
+      "issues": 180,
+      "pushed_at": "2026-04-25T16:57:37Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": {
+        "tag": "v18.0.11",
+        "url": "https://github.com/ryoppippi/ccusage/releases/tag/v18.0.11",
+        "published_at": "2026-04-19T10:55:07Z"
+      }
+    },
+    "sangrokjung/claude-forge": {
+      "stars": 661,
+      "forks": 149,
+      "watchers": 6,
+      "issues": 27,
+      "pushed_at": "2026-04-24T15:13:54Z",
+      "language": "Shell",
+      "archived": false,
+      "release": {
+        "tag": "v3.0.1",
+        "url": "https://github.com/sangrokjung/claude-forge/releases/tag/v3.0.1",
+        "published_at": "2026-04-23T06:39:50Z"
+      }
+    },
+    "severity1/claude-code-auto-memory": {
+      "stars": 138,
+      "forks": 12,
+      "watchers": 3,
+      "issues": 5,
+      "pushed_at": "2026-04-18T03:09:56Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v0.9.2",
+        "url": "https://github.com/severity1/claude-code-auto-memory/releases/tag/v0.9.2",
+        "published_at": "2026-04-18T03:04:07Z"
+      }
+    },
+    "shinpr/claude-code-discover": {
+      "stars": 1,
+      "forks": 2,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-04-06T11:20:54Z",
+      "language": null,
+      "archived": false,
+      "release": {
+        "tag": "v0.3.0",
+        "url": "https://github.com/shinpr/claude-code-discover/releases/tag/v0.3.0",
+        "published_at": "2026-04-06T11:20:55Z"
+      }
+    },
+    "shinpr/claude-code-workflows": {
+      "stars": 320,
+      "forks": 61,
+      "watchers": 5,
+      "issues": 0,
+      "pushed_at": "2026-04-15T03:43:50Z",
+      "language": null,
+      "archived": false,
+      "release": {
+        "tag": "v0.16.14",
+        "url": "https://github.com/shinpr/claude-code-workflows/releases/tag/v0.16.14",
+        "published_at": "2026-04-14T14:20:25Z"
+      }
+    },
+    "shinpr/linear-prism": {
+      "stars": 4,
+      "forks": 0,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-04-04T11:18:48Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v0.1.0",
+        "url": "https://github.com/shinpr/linear-prism/releases/tag/v0.1.0",
+        "published_at": "2026-04-04T11:18:48Z"
+      }
+    },
+    "shinpr/metronome": {
+      "stars": 5,
+      "forks": 1,
+      "watchers": 0,
+      "issues": 0,
+      "pushed_at": "2026-04-04T07:37:15Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v0.1.3",
+        "url": "https://github.com/shinpr/metronome/releases/tag/v0.1.3",
+        "published_at": "2026-01-30T13:22:44Z"
+      }
+    },
+    "snyk/agent-scan": {
+      "stars": 2249,
+      "forks": 208,
+      "watchers": 15,
+      "issues": 21,
+      "pushed_at": "2026-04-25T07:53:07Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v0.4.18",
+        "url": "https://github.com/snyk/agent-scan/releases/tag/v0.4.18",
+        "published_at": "2026-04-23T15:11:36Z"
+      }
+    },
+    "st0012/ruby-skills": {
+      "stars": 111,
+      "forks": 7,
+      "watchers": 5,
+      "issues": 3,
+      "pushed_at": "2026-04-05T11:34:22Z",
+      "language": "Shell",
+      "archived": false,
+      "release": null
+    },
+    "steipete/claude-code-mcp": {
+      "stars": 1246,
+      "forks": 157,
+      "watchers": 6,
+      "issues": 17,
+      "pushed_at": "2026-01-01T13:18:45Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": {
+        "tag": "v1.10.2",
+        "url": "https://github.com/steipete/claude-code-mcp/releases/tag/v1.10.2",
+        "published_at": "2025-05-17T04:11:27Z"
+      }
+    },
+    "stripe/ai": {
+      "stars": 1504,
+      "forks": 257,
+      "watchers": 15,
+      "issues": 49,
+      "pushed_at": "2026-04-25T00:52:33Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": null
+    },
+    "supabase/agent-skills": {
+      "stars": 2002,
+      "forks": 133,
+      "watchers": 9,
+      "issues": 12,
+      "pushed_at": "2026-04-24T20:17:01Z",
+      "language": "TypeScript",
+      "archived": false,
+      "release": null
+    },
+    "timescale/pg-aiguide": {
+      "stars": 1702,
+      "forks": 84,
+      "watchers": 13,
+      "issues": 25,
+      "pushed_at": "2026-04-23T14:17:23Z",
+      "language": "Python",
+      "archived": false,
+      "release": {
+        "tag": "v0.5.0",
+        "url": "https://github.com/timescale/pg-aiguide/releases/tag/v0.5.0",
+        "published_at": "2026-04-23T14:17:13Z"
+      }
+    },
+    "trailofbits/skills": {
+      "stars": 4795,
+      "forks": 415,
+      "watchers": 53,
+      "issues": 28,
+      "pushed_at": "2026-04-24T04:56:08Z",
+      "language": "Python",
+      "archived": false,
+      "release": null
+    },
+    "vercel-labs/agent-skills": {
+      "stars": 25697,
+      "forks": 2337,
+      "watchers": 115,
+      "issues": 131,
+      "pushed_at": "2026-04-20T21:13:10Z",
+      "language": "JavaScript",
+      "archived": false,
+      "release": null
+    },
+    "wshobson/agents": {
+      "stars": 34281,
+      "forks": 3713,
+      "watchers": 316,
+      "issues": 9,
+      "pushed_at": "2026-04-18T18:30:34Z",
+      "language": "Python",
+      "archived": false,
+      "release": null
+    },
+    "zippoxer/recall": {
+      "stars": 183,
+      "forks": 16,
+      "watchers": 0,
+      "issues": 9,
+      "pushed_at": "2026-01-14T07:49:57Z",
+      "language": "Rust",
+      "archived": false,
+      "release": {
+        "tag": "v0.5.0",
+        "url": "https://github.com/zippoxer/recall/releases/tag/v0.5.0",
+        "published_at": "2026-01-13T18:50:54Z"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The RepoStats component fetched GitHub data from the browser using the unauthenticated API (60 req/hr per IP). Behind a CDN, multiple users sharing an IP can exhaust that budget quickly, causing stats to silently fall back to "—".

Replace with a CI-driven pipeline: `scripts/fetch-repo-stats.js` runs daily via a new GitHub Actions workflow, using GITHUB_TOKEN (5000 req/hr) to collect stars, forks, watchers, open issues, last-push date, language, archive status, and latest release for every GitHub-sourced plugin. Results land in `stats/repos.json`; the Astro component reads them at build time and renders static HTML — no browser API calls, no rate-limit risk.

The deploy workflow is updated to chain after the new repo stats collection workflow so the site always ships fresh data.

## Summary

<!-- What does this PR change, and why? -->

### Type of change

- [ ] Add a plugin → please use the [add-plugin template](?template=add-plugin.md) instead
- [ ] Update a plugin → please use the [update-plugin template](?template=update-plugin.md) instead
- [ ] Remove a plugin → please use the [remove-plugin template](?template=remove-plugin.md) instead
- [ ] Marketplace / registry change (schema, validation, `plugins/` tooling)
- [ ] Site / docs change (landing page, README, content)
- [ ] CI / workflow / repo tooling
- [x] Bug fix
- [ ] Other

### Checklist

- [x] I have read and understood the [contributing guidelines](../CONTRIBUTING.md)
- [x] Changes are scoped and focused on a single concern
- [x] Tested locally where applicable
- [x] Updated relevant docs (README, site content, etc.) if behavior changed
- [x] Did **not** hand-edit `marketplace.json` (it is generated)
