### PR TITLE
fix(github): Update github workflows and PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,10 @@
 
 ### Checklist
 
-- [ ] I have read and understood the [contributing guidelines](../CONTRIBUTING.md)
-- [ ] Changes are scoped and focused on a single concern
-- [ ] Tested locally where applicable
-- [ ] Updated relevant docs (README, site content, etc.) if behavior changed
-- [ ] Did **not** hand-edit `marketplace.json` (it is generated)
+_Uncheck any item that does not apply or has not been completed._
+
+- [x] I have read and understood the [contributing guidelines](../CONTRIBUTING.md)
+- [x] Changes are scoped and focused on a single concern
+- [x] Tested locally where applicable
+- [x] Updated relevant docs (README, site content, etc.) if behavior changed
+- [x] Did **not** hand-edit `marketplace.json` (it is generated)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,9 @@
 
 ### Type of change
 
-- [ ] Add a plugin → please use the [add-plugin template](?template=add-plugin.md) instead
-- [ ] Update a plugin → please use the [update-plugin template](?template=update-plugin.md) instead
-- [ ] Remove a plugin → please use the [remove-plugin template](?template=remove-plugin.md) instead
+- [ ] Add a plugin → please use the [add-plugin template](?expand=1&template=add-plugin.md) instead
+- [ ] Update a plugin → please use the [update-plugin template](?expand=1&template=update-plugin.md) instead
+- [ ] Remove a plugin → please use the [remove-plugin template](?expand=1&template=remove-plugin.md) instead
 - [ ] Marketplace / registry change (schema, validation, `plugins/` tooling)
 - [ ] Site / docs change (landing page, README, content)
 - [ ] CI / workflow / repo tooling

--- a/.github/PULL_REQUEST_TEMPLATE/add-plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add-plugin.md
@@ -10,15 +10,17 @@
 
 ### Checklist
 
-- [ ] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
-- [ ] Plugin has a valid `.claude-plugin/plugin.json` manifest
-- [ ] Plugin has a `README.md`
-- [ ] Plugin has a `LICENSE`
-- [ ] Plugin name is kebab-case
-- [ ] `category` is set to one of the allowed values
-- [ ] `tags` includes at least one component type (skills/agents/hooks/commands/mcp-servers/lsp-servers/integration/other)
-- [ ] Plugin file added to `plugins/` directory (do not edit `marketplace.json`)
-- [ ] Tested locally with `/plugin marketplace add` and `/plugin install`
+_Uncheck any item that does not apply or has not been completed._
+
+- [x] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
+- [x] Plugin has a valid `.claude-plugin/plugin.json` manifest
+- [x] Plugin has a `README.md`
+- [x] Plugin has a `LICENSE`
+- [x] Plugin name is kebab-case
+- [x] `category` is set to one of the allowed values
+- [x] `tags` includes at least one component type (skills/agents/hooks/commands/mcp-servers/lsp-servers/integration/other)
+- [x] Plugin file added to `plugins/` directory (do not edit `marketplace.json`)
+- [x] Tested locally with `/plugin marketplace add` and `/plugin install`
 
 ### What does this plugin do?
 

--- a/.github/PULL_REQUEST_TEMPLATE/remove-plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/remove-plugin.md
@@ -4,9 +4,11 @@
 
 ### Checklist
 
-- [ ] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
-- [ ] I am the original author or maintainer of this plugin
-- [ ] Plugin file removed from `plugins/` directory (do not edit `marketplace.json`)
+_Uncheck any item that does not apply or has not been completed._
+
+- [x] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
+- [x] I am the original author or maintainer of this plugin
+- [x] Plugin file removed from `plugins/` directory (do not edit `marketplace.json`)
 
 ### Reason for removal (Optional)
 

--- a/.github/PULL_REQUEST_TEMPLATE/update-plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/update-plugin.md
@@ -16,10 +16,12 @@
 
 ### Checklist
 
-- [ ] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
-- [ ] I am the original author or maintainer of this plugin
-- [ ] Only my plugin's file in `plugins/` is modified (do not edit `marketplace.json`)
-- [ ] Tested locally with `/plugin marketplace add` and `/plugin install`
+_Uncheck any item that does not apply or has not been completed._
+
+- [x] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
+- [x] I am the original author or maintainer of this plugin
+- [x] Only my plugin's file in `plugins/` is modified (do not edit `marketplace.json`)
+- [x] Tested locally with `/plugin marketplace add` and `/plugin install`
 
 ### Reason for update
 

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -19,6 +19,18 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
+      - name: Detect added/modified plugin files
+        id: changes
+        run: |
+          # Pure-deletion PRs (plugin removal) have nothing to validate or
+          # advertise — skip the bot comment entirely on those.
+          changed=$(git diff --name-only --diff-filter=AM origin/${{ github.base_ref }} -- 'plugins/*.json')
+          if [ -z "$changed" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check for duplicate plugins
         id: duplicates
         run: |
@@ -214,7 +226,7 @@ jobs:
           fi
 
       - name: Comment on PR
-        if: always()
+        if: always() && steps.changes.outputs.has_changes == 'true'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
GitHub requires the `expand=1` query parameter in template URLs to actually open the new-PR form pre-filled with the chosen template. Without it, clicking the link loads the template selector but does not populate the body, leaving contributors with a blank form.

## Summary

<!-- What does this PR change, and why? -->

### Type of change

- [ ] Add a plugin → please use the [add-plugin template](?template=add-plugin.md) instead
- [ ] Update a plugin → please use the [update-plugin template](?template=update-plugin.md) instead
- [ ] Remove a plugin → please use the [remove-plugin template](?template=remove-plugin.md) instead
- [ ] Marketplace / registry change (schema, validation, `plugins/` tooling)
- [ ] Site / docs change (landing page, README, content)
- [x] CI / workflow / repo tooling
- [ ] Bug fix
- [ ] Other

### Checklist

- [x] I have read and understood the [contributing guidelines](../CONTRIBUTING.md)
- [x] Changes are scoped and focused on a single concern
- [x] Tested locally where applicable
- [x] Updated relevant docs (README, site content, etc.) if behavior changed
- [x] Did **not** hand-edit `marketplace.json` (it is generated)
