### PR TITLE
feat(site): show view count on plugin detail pages

### DIFF
--- a/site/src/components/plugin/PluginHeader.astro
+++ b/site/src/components/plugin/PluginHeader.astro
@@ -7,6 +7,7 @@ interface Props {
   license?: string;
   category: string;
   categoryColor: string;
+  viewCount: number;
 }
 
 const {
@@ -17,7 +18,17 @@ const {
   license,
   category,
   categoryColor,
+  viewCount,
 } = Astro.props;
+
+const displayedViews = viewCount + 1;
+const viewsText = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+}).format(displayedViews);
+const viewsTitle = `${displayedViews.toLocaleString()} ${
+  displayedViews === 1 ? "view" : "views"
+} (includes this visit)`;
 ---
 
 <header class="mb-6 flex flex-wrap items-start justify-between gap-4">
@@ -56,11 +67,33 @@ const {
           </span>
         </>
       )}
+      <span class="text-gray-600">•</span>
+      <span
+        class={`rounded-full px-2.5 py-0.5 text-xs font-medium ${categoryColor}`}
+      >
+        {category}
+      </span>
     </div>
   </div>
   <span
-    class={`shrink-0 rounded-full px-3 py-1 text-sm font-medium ${categoryColor}`}
+    class="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-sm font-medium text-gray-300"
+    title={viewsTitle}
+    aria-label={viewsTitle}
   >
-    {category}
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"></path>
+      <circle cx="12" cy="12" r="3"></circle>
+    </svg>
+    <span class="font-mono">{viewsText}</span>
   </span>
 </header>

--- a/site/src/lib/plugins.ts
+++ b/site/src/lib/plugins.ts
@@ -9,7 +9,7 @@ const statsPath = resolve(process.cwd(), "../stats/plugins.json");
 
 export type Plugin = Record<string, any> & { name: string };
 
-function loadViewCounts(): Record<string, number> {
+export function loadViewCounts(): Record<string, number> {
   try {
     const stats = JSON.parse(readFileSync(statsPath, "utf-8"));
     return stats.plugins || {};

--- a/site/src/pages/plugins/[name].astro
+++ b/site/src/pages/plugins/[name].astro
@@ -14,6 +14,7 @@ import {
   getSourceRepo,
   getSourceLabel,
 } from "../../lib/source";
+import { loadViewCounts } from "../../lib/plugins";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -76,6 +77,8 @@ const categoryColors: Record<string, string> = {
   other: "bg-gray-500/20 text-gray-300",
 };
 const categoryColor = categoryColors[plugin.category] || categoryColors.other;
+
+const viewCount = loadViewCounts()[plugin.name] ?? 0;
 
 const authorKey = plugin.author.username;
 const sameAuthor = allPlugins.filter(
@@ -200,6 +203,7 @@ const jsonLd = {
         license={plugin.license}
         category={plugin.category}
         categoryColor={categoryColor}
+        viewCount={viewCount}
       />
 
       <p class="mb-6 text-lg leading-relaxed text-gray-300">


### PR DESCRIPTION
Plugin detail pages already had a category badge in the top-right corner, but no indication of popularity. Surface the GoatCounter view count (already loaded for plugin sorting) as a badge in that slot, and move the category badge inline with the other metadata pills.

The count is formatted with `Intl.NumberFormat` compact notation (e.g. `1.2K`) and incremented by 1 to reflect the current visit, with a tooltip showing the exact number.

## Summary

<!-- What does this PR change, and why? -->

### Type of change

- [ ] Add a plugin → please use the [add-plugin template](?expand=1&template=add-plugin.md) instead
- [ ] Update a plugin → please use the [update-plugin template](?expand=1&template=update-plugin.md) instead
- [ ] Remove a plugin → please use the [remove-plugin template](?expand=1&template=remove-plugin.md) instead
- [ ] Marketplace / registry change (schema, validation, `plugins/` tooling)
- [x] Site / docs change (landing page, README, content)
- [ ] CI / workflow / repo tooling
- [ ] Bug fix
- [ ] Other

### Checklist

_Uncheck any item that does not apply or has not been completed._

- [x] I have read and understood the [contributing guidelines](../CONTRIBUTING.md)
- [x] Changes are scoped and focused on a single concern
- [x] Tested locally where applicable
- [x] Updated relevant docs (README, site content, etc.) if behavior changed
- [x] Did **not** hand-edit `marketplace.json` (it is generated)
