### PR TITLE
feat(plugins): add iconify plugin manifest

### DIFF
--- a/plugins/iconify.json
+++ b/plugins/iconify.json
@@ -1,0 +1,16 @@
+{
+  "name": "iconify",
+  "source": {
+    "source": "npm",
+    "package": "@anistark/iconify"
+  },
+  "description": "Turn a logo image into a favicon set (16x16.ico + 16/48/128 PNG) without leaving Claude Code.",
+  "version": "0.2.1",
+  "author": {
+    "username": "anistark",
+    "name": "Kumar Anirudha"
+  },
+  "category": "development",
+  "tags": ["commands", "icons", "favicon", "images"],
+  "license": "MIT"
+}


### PR DESCRIPTION
## Add Plugin

**Plugin name:** `iconify`
**Source:** [@anistark/iconify](https://www.npmjs.com/package/@anistark/iconify)
**License:** cc
**Category:** development
**Type / tags:** skills, commands

### Checklist

_Uncheck any item that does not apply or has not been completed._

- [x] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
- [x] Plugin has a valid `.claude-plugin/plugin.json` manifest
- [x] Plugin has a `README.md`
- [x] Plugin has a `LICENSE`
- [x] Plugin name is kebab-case
- [x] `category` is set to one of the allowed values
- [x] `tags` includes at least one component type (skills/agents/hooks/commands/mcp-servers/lsp-servers/integration/other)
- [x] Plugin file added to `plugins/` directory (do not edit `marketplace.json`)
- [x] Tested locally with `/plugin marketplace add` and `/plugin install`

### What does this plugin do?

<!-- Brief description -->
Registers the `@anistark/iconify` npm plugin, which converts a logo image into a favicon set (16×16 ICO + 16/48/128 PNG) without leaving Claude Code. Authored by anistark (Kumar Anirudha), MIT-licensed, categorized under development.