### PR TITLE
feat(plugins): add feluda license compliance skill

### DIFF
--- a/plugins/feluda.json
+++ b/plugins/feluda.json
@@ -1,0 +1,17 @@
+{
+  "name": "feluda",
+  "source": {
+    "source": "git-subdir",
+    "url": "https://github.com/anistark/feluda.git",
+    "path": "skills/feluda"
+  },
+  "description": "License compliance skill for Claude Code — automatically runs feluda before committing new dependencies and surfaces GPL/AGPL/restrictive license warnings inline. Supports Rust, Node.js, Go, Python, Java, .NET, Ruby, PHP, C/C++, and R.",
+  "version": "1.0.0",
+  "author": {
+    "username": "anistark",
+    "name": "Kumar Anirudha"
+  },
+  "category": "security",
+  "tags": ["skills", "rust", "license", "compliance"],
+  "license": "MIT"
+}


### PR DESCRIPTION
Registers the `feluda` plugin — a license compliance skill that runs automatically before committing new dependencies and surfaces GPL/AGPL/restrictive license warnings inline.

Supports Rust, Node.js, Go, Python, Java, .NET, Ruby, PHP, C/C++, and R projects.

To be merged once [PR 216](https://github.com/anistark/feluda/pull/216) is merged and released.

## Add Plugin

**Plugin name:**
**Source:** https://github.com/anistark/feluda
**License:** MIT
**Category:** security
**Type / tags:** skills, rust, license, compliance

### Checklist

_Uncheck any item that does not apply or has not been completed._

- [x] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
- [x] Plugin has a valid `.claude-plugin/plugin.json` manifest
- [x] Plugin has a `README.md`
- [x] Plugin has a `LICENSE`
- [x] Plugin name is kebab-case
- [x] `category` is set to one of the allowed values
- [x] `tags` includes at least one component type (skills/agents/hooks/commands/mcp-servers/lsp-servers/integration/other)
- [x] Plugin file added to `plugins/` directory (do not edit `marketplace.json`)
- [x] Tested locally with `/plugin marketplace add` and `/plugin install`
