### PR TITLE
Add Hermes Tweet plugin

### DIFF
--- a/plugins/hermes-tweet.json
+++ b/plugins/hermes-tweet.json
@@ -1,0 +1,23 @@
+{
+  "name": "hermes-tweet",
+  "source": {
+    "source": "github",
+    "repo": "Xquik-dev/hermes-tweet",
+    "sha": "341e991dd21e10105caf1456102f36b246f6e86e"
+  },
+  "description": "Native Hermes Agent plugin for X and Twitter automation with read-first workflows and approval-gated actions.",
+  "version": "0.1.6",
+  "author": {
+    "username": "Xquik-dev",
+    "name": "Xquik-dev"
+  },
+  "category": "productivity",
+  "license": "MIT",
+  "tags": [
+    "skills",
+    "integration",
+    "social-media",
+    "twitter",
+    "x"
+  ]
+}


### PR DESCRIPTION
## Add Plugin

**Plugin name:** hermes-tweet
**Source:** GitHub repo, Xquik-dev/hermes-tweet pinned to 341e991dd21e10105caf1456102f36b246f6e86e
**License:** MIT
**Category:** productivity
**Type / tags:** ["skills", "integration", "social-media", "twitter", "x"]

### Checklist

- [x] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
- [x] Plugin has a valid `.claude-plugin/plugin.json` manifest
- [x] Plugin has a `README.md`
- [x] Plugin has a `LICENSE`
- [x] Plugin name is kebab-case
- [x] `category` is set to one of the allowed values
- [x] `tags` includes at least one component type (skills/agents/hooks/commands/mcp-servers/lsp-servers/integration/other)
- [x] Plugin file added to `plugins/` directory (do not edit `marketplace.json`)
- [ ] Tested locally with `/plugin marketplace add` and `/plugin install`

### What does this plugin do?

Hermes Tweet is a native Hermes Agent plugin for X and Twitter automation. It provides read-first social media workflows plus approval-gated actions through a source repository that includes a Claude plugin manifest, README, and MIT license.

### Validation

- `jq empty plugins/hermes-tweet.json`
- exact-field `jq -e` check for name, source, sha, version, category, license, and tags
- duplicate name/source checks against existing `plugins/*.json`
- `./scripts/build-marketplace.sh`
- `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- `git diff --check`
- added-line public safety scan for secrets and private implementation terms
- source repository link returned HTTP 200