### PR TITLE
Add Xquik x-twitter-scraper plugin

### DIFF
--- a/plugins/x-twitter-scraper.json
+++ b/plugins/x-twitter-scraper.json
@@ -1,0 +1,23 @@
+{
+  "name": "x-twitter-scraper",
+  "source": {
+    "source": "github",
+    "repo": "Xquik-dev/x-twitter-scraper"
+  },
+  "description": "Xquik X data automation skill with REST API, MCP, webhooks, SDKs, extraction workflows, and confirmation-gated actions.",
+  "version": "2.4.16",
+  "author": {
+    "username": "Xquik-dev",
+    "name": "Xquik"
+  },
+  "category": "data",
+  "tags": [
+    "skills",
+    "mcp-servers",
+    "integration",
+    "x-api",
+    "webhooks",
+    "social-media"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
## Add Plugin

**Plugin name:** `x-twitter-scraper`
**Source:** GitHub repo `Xquik-dev/x-twitter-scraper`
**License:** MIT
**Category:** data
**Type / tags:** `skills`, `mcp-servers`, `integration`, `x-api`, `webhooks`, `social-media`

### Checklist

- [x] I have read and understood the contributing guidelines
- [x] Plugin has a valid `.claude-plugin/plugin.json` manifest
- [x] Plugin has a `README.md`
- [x] Plugin has a `LICENSE`
- [x] Plugin name is kebab-case
- [x] `category` is set to one of the allowed values
- [x] `tags` includes at least one component type
- [x] Plugin file added to `plugins/` directory and `marketplace.json` was not edited
- [ ] Tested locally with marketplace add and plugin install

### What does this plugin do?

Adds the Xquik `x-twitter-scraper` plugin to AgentHub. It provides X data automation skills for REST API workflows, MCP access, webhooks, SDK setup, extraction tasks, and confirmation-gated actions.

### Validation

- Parsed `plugins/x-twitter-scraper.json` as valid JSON.
- Ran `git diff` whitespace checks.
- Confirmed the source repo exposes `.claude-plugin/plugin.json` with version `2.4.16`, MIT license, skills, and MCP config.
- Confirmed the source repo has `README.md` and `LICENSE`.
- Checked AgentHub for existing Xquik code, PRs, and issues. No duplicate Xquik entry was found.
- Checked Xquik docs and source repo links.
