### PR TITLE
Update Hermes Tweet source SHA

### DIFF
--- a/plugins/hermes-tweet.json
+++ b/plugins/hermes-tweet.json
@@ -3,7 +3,7 @@
   "source": {
     "source": "github",
     "repo": "Xquik-dev/hermes-tweet",
-    "sha": "341e991dd21e10105caf1456102f36b246f6e86e"
+    "sha": "cd67f9c0b5b56df0906bccf900d4054d996f285c"
   },
   "description": "Native Hermes Agent plugin for X and Twitter automation with read-first workflows and approval-gated actions.",
   "version": "0.1.6",


### PR DESCRIPTION
## Update Plugin

**Plugin name:** hermes-tweet

### Update type

- [ ] Version bump
- [ ] Description change
- [ ] Category change
- [ ] Tags / type change
- [x] Source change (e.g. moved repo, switched to npm)
- [ ] Author/metadata update
- [ ] Other

### Checklist

- [x] I have read and understood the contributing guidelines
- [x] I am the original author or maintainer of this plugin
- [x] Only my plugin's file in `plugins/` is modified
- [ ] Tested locally with `/plugin marketplace add` and `/plugin install`

### Reason for update

Refresh the pinned Hermes Tweet source SHA to the current public `Xquik-dev/hermes-tweet` master commit while keeping the existing `0.1.6` marketplace version and metadata unchanged.

Validation:

- Read `README.md`, `CONTRIBUTING.md`, and `AGENTS.md`.
- Confirmed `plugins/hermes-tweet.json` already exists and no open duplicate Hermes Tweet, Xquik, TweetClaw, Twitter, or X/Twitter PR or issue exists.
- Confirmed AgentHub is MIT licensed and Hermes Tweet is MIT licensed.
- `jq -e . plugins/hermes-tweet.json`
- Source commit link returned HTTP 200.
- Added-line review found only the source SHA update.