### PR TITLE
feat: add llm-box plugin

### DIFF
--- a/plugins/llm-box.json
+++ b/plugins/llm-box.json
@@ -1,0 +1,25 @@
+{
+  "name": "llm-box",
+  "source": {
+    "source": "git",
+    "url": "https://github.com/alib8b8/llm-box.git"
+  },
+  "description": "Terminal-first workflow automation engine. Generate and execute YAML workflows from plain English descriptions. Features 20+ built-in nodes, 15+ LLM providers, and MCP server mode.",
+  "version": "0.3.0",
+  "author": {
+    "username": "alib8b8",
+    "name": "alib8b8"
+  },
+  "category": "development",
+  "tags": [
+    "skills",
+    "commands",
+    "mcp-servers",
+    "workflow",
+    "automation",
+    "cli",
+    "yaml",
+    "llm"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
## Add Plugin

**Plugin name:** llm-box
**Source:** https://github.com/alib8b8/llm-box
**License:** MIT
**Category:** development
**Type / tags:** skills, commands, mcp-servers, workflow, automation, cli, yaml, llm

### Checklist

- [x] I have read and understood the [contributing guidelines](../../CONTRIBUTING.md)
- [x] Plugin has a valid `.claude-plugin/plugin.json` manifest
- [x] Plugin has a `README.md`
- [x] Plugin has a `LICENSE`
- [x] Plugin name is kebab-case
- [x] `category` is set to one of the allowed values
- [x] `tags` includes at least one component type (skills/agents/hooks/commands/mcp-servers/lsp-servers/integration/other)
- [x] Plugin file added to `plugins/` directory (do not edit `marketplace.json`)
- [x] Tested locally with `/plugin marketplace add` and `/plugin install`

### What does this plugin do?

llm-box is a terminal-first workflow automation engine that generates and executes YAML workflows from plain English descriptions.

**Key features:**
- Natural language to YAML workflow generation
- 20+ built-in nodes (fetch_url, http_request, execute, json_parse, file operations, etc.)
- 15+ LLM providers (Ollama, DeepSeek, OpenAI-compatible, and more)
- Built-in MCP server mode (stdio + HTTP/SSE for remote access)
- 3 slash commands: /create-workflow, /run-workflow, /list-nodes
- 2 skills: workflow (auto-activated) + setup (user-invoked)
- Safe mode for restricted execution environments

**Security features:**
- SSRF protection on URL fetching (blocked private/local IP ranges)
- Path traversal protection on file operations
- Command injection prevention via argument list execution
- Confirmation gates for destructive operations

**Files included:**
- `.claude-plugin/plugin.json` + `marketplace.json`
- `skills/llm-box/SKILL.md` (workflow skill, auto-activated)
- `skills/setup/SKILL.md` (setup/installation skill)
- `commands/` (3 slash commands)
- `.mcp.json`
- `README.md` + `README.zh-CN.md`